### PR TITLE
added sslmode postgres

### DIFF
--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -97,6 +97,7 @@ DATABASE_USER = os.getenv("DATABASE_USER") or os.getenv("MYSQL_USER")
 DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD") or os.getenv("MYSQL_PASSWORD")
 DATABASE_HOST = os.getenv("DATABASE_HOST") or os.getenv("MYSQL_HOST")
 DATABASE_PORT = os.getenv("DATABASE_PORT") or os.getenv("MYSQL_PORT")
+DATABASE_SSL_MODE = os.getenv("DATABASE_SSL_MODE")
 
 DATABASE_TYPE = os.getenv("DATABASE_TYPE", DatabaseTypes.MYSQL).lower()
 assert DATABASE_TYPE in {DatabaseTypes.MYSQL, DatabaseTypes.POSTGRESQL, DatabaseTypes.SQLITE3}
@@ -127,6 +128,9 @@ DATABASE_CONFIGS = {
         "PASSWORD": DATABASE_PASSWORD,
         "HOST": DATABASE_HOST,
         "PORT": DATABASE_PORT,
+        "OPTIONS": {
+            "sslmode": DATABASE_SSL_MODE
+        },
     },
 }
 

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -147,6 +147,8 @@
   value: {{ include "snippet.postgresql.db" . }}
 - name: DATABASE_USER
   value: {{ include "snippet.postgresql.user" . }}
+- name: DATABASE_SSL_MODE
+  value: {{ include "snippet.postgresql.sslmode" . }}
 - name: DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -206,6 +206,7 @@ externalPostgresql:
   existingSecret: ""
   # the key in the secret containing the database password
   passwordKey: password
+  sslmode: 
 
 # RabbitMQ is included into this release for the convenience.
 # It is recommended to host it separately from this release


### PR DESCRIPTION
**What this PR does**: adds sslmode postgres toggle to helm chart and django settings

**Which issue(s) this PR fixes**: there's no way to connect to ssl-protected postgresql from production helm chart

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated