### PR TITLE
fix existingSecret to default value (see #761)

### DIFF
--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -242,7 +242,7 @@ externalRabbitmq:
   # use an existing secret for the rabbitmq password
   existingSecret: ""
   # the key in the secret containing the rabbitmq password
-  passwordKey: password
+  passwordKey: ""
   # the key in the secret containing the rabbitmq username
   usernameKey: username
 


### PR DESCRIPTION
**What this PR does**:
The existing value brokes the release when using external RabbitMQ. 
```
 Warning  Failed     6s (x11 over 112s)  kubelet            Error: couldn't find key password in Secret monitoring/oncall-rabbitmq-external
```

**Which issue(s) this PR fixes**:
Related MR [#761](https://github.com/grafana/oncall/pull/761)

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated